### PR TITLE
feat: Enhance model docs, tests, and source freshness

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ This project follows a medallion architecture approach with the following layers
 - **Incremental Data Processing:** Applied incremental load strategies (e.g., `merge`) to staging and intermediate models for efficiency, optimized for Databricks Delta Lake.
 - **Databricks Optimization:** Addressed Databricks-specific SQL syntax and limitations, including `partition_by` requirements, usage of `LATERAL VIEW EXPLODE` for array unnesting, and `event_id` sanitization for compatibility.
 - **Custom dbt Macros:** Developed reusable macros for common transformations, such as Unix timestamp conversion (`to_timestamp_from_unix`) and millisecond to second conversion (`convert_milliseconds_to_seconds`), enhancing code modularity and maintainability.
-- **Data Quality & Documentation:** Established comprehensive YAML documentation and dbt tests for models across layers, ensuring data integrity and understanding.
+- **Data Quality & Documentation:** Established comprehensive YAML documentation and dbt tests (including primary key, not-null, and relationship tests) for models across all layers, ensuring data integrity and understanding.
+- **Source Data Monitoring:** Implemented source freshness checks to monitor the timeliness of incoming raw data, with warnings configured for stale data (e.g., for the `events` source).
 - **Standardized Schema Management:** Centralized and dynamic schema configuration for all model layers in `dbt_project.yml`, promoting consistency across environments.
 - **Code Conventions:** Adherence to SQL formatting (leading commas) and project structure best practices throughout the development process.
 
@@ -165,6 +166,11 @@ The project uses a combination of configurations in `dbt_project.yml` and a cust
 The project includes data quality tests for key fields:
 ```bash
 dbt test
+```
+
+To check the freshness of your source data:
+```bash
+dbt source freshness
 ```
 
 ## Documentation

--- a/models/marts/fact/_fact.yml
+++ b/models/marts/fact/_fact.yml
@@ -1,0 +1,167 @@
+version: 2
+
+models:
+  - name: fact_venue_activity
+    description: >
+      Daily activity metrics for each venue. Includes counts of events, 
+      groups using the venue, and cancelled events. Also flags the first 
+      and last day a venue hosted an event.
+    columns:
+      - name: venue_sk
+        description: Surrogate key for the venue, from dim_venues.
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_venues')
+              field: venue_sk
+
+      - name: activity_date
+        description: The date for which the activity metrics are calculated.
+        tests:
+          - not_null
+
+      - name: venue_id
+        description: The original identifier for the venue.
+
+      - name: venue_name
+        description: The name of the venue.
+
+      - name: daily_events
+        description: Count of distinct events held at the venue on the activity_date.
+
+      - name: daily_groups
+        description: Count of distinct groups that held events at the venue on the activity_date.
+
+      - name: cancelled_events
+        description: Count of events scheduled at the venue on the activity_date that were cancelled.
+
+      - name: is_first_event_date
+        description: Boolean flag, true if this activity_date is the first date the venue hosted an event.
+
+      - name: is_last_event_date
+        description: Boolean flag, true if this activity_date is the most recent date the venue hosted an event.
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - venue_sk
+            - activity_date
+
+  - name: fact_group_memberships
+    description: >
+      Provides a snapshot of the latest version of each user's membership 
+      in a group. Includes membership attributes, user details, group details, 
+      and derived metrics like membership age.
+    columns:
+      - name: membership_sk
+        description: Surrogate key for the user-group membership, from int_user_memberships_with_groups.
+        tests:
+          - not_null
+          - unique
+
+      - name: user_sk
+        description: Surrogate key for the user, from dim_users.
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_users')
+              field: user_sk
+
+      - name: group_sk
+        description: Surrogate key for the group, from dim_groups.
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_groups')
+              field: group_sk
+
+      - name: user_id
+        description: The original identifier for the user.
+
+      - name: group_id
+        description: The original identifier for the group.
+
+      - name: joined_at
+        description: Timestamp when the user joined the group.
+
+      - name: joined_date
+        description: Date when the user joined the group.
+
+      - name: membership_version_number
+        description: Version number of the membership record (if applicable, e.g., for SCD type 2).
+
+      - name: days_from_group_creation_to_join
+        description: Number of days between the group's creation and the user joining.
+
+      - name: is_early_adopter
+        description: Boolean flag, true if the user joined the group shortly after its creation.
+
+      - name: group_name
+        description: Name of the group at the time of join.
+
+      - name: group_city
+        description: City of the group at the time of join.
+
+      - name: group_created_at
+        description: Timestamp when the group was created.
+
+      - name: user_city
+        description: City of the user.
+
+      - name: user_country
+        description: Country of the user.
+
+      - name: user_hometown
+        description: Hometown of the user.
+
+      - name: membership_age_days
+        description: Current age of the membership in days.
+
+      - name: membership_age_months
+        description: Current age of the membership in months.
+
+  - name: fact_group_activity
+    description: >
+      Daily membership activity metrics for each group. Includes counts of 
+      new members and new early adopters. Also flags the first and last day 
+      a group had a new member join.
+    columns:
+      - name: group_sk
+        description: Surrogate key for the group, from dim_groups.
+        tests:
+          - not_null
+          - relationships:
+              to: ref('dim_groups')
+              field: group_sk
+
+      - name: activity_date
+        description: The date for which the group activity metrics are calculated.
+        tests:
+          - not_null
+
+      - name: group_id
+        description: The original identifier for the group.
+
+      - name: group_name
+        description: The name of the group.
+
+      - name: new_members
+        description: Count of new members who joined the group on the activity_date.
+
+      - name: new_early_adopters
+        description: Count of new members who joined as early adopters on the activity_date.
+
+      - name: is_first_member_date
+        description: Boolean flag, true if this activity_date is the first date a member joined this group.
+
+      - name: is_latest_member_date
+        description: Boolean flag, true if this activity_date is the most recent date a member joined this group.
+
+      - name: days_since_creation
+        description: Number of days from group creation to the activity_date.
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - group_sk
+            - activity_date

--- a/models/marts/fact/fact_venue_activity.sql
+++ b/models/marts/fact/fact_venue_activity.sql
@@ -20,6 +20,7 @@ daily_venue_metrics as (
         sum(case when is_cancelled then 1 else 0 end) as cancelled_events
     from events_with_venues
     where venue_id is not null
+      and event_start_time is not null -- Ensure activity_date can be derived
     group by 1, 2
 ),
 

--- a/models/staging/_sources.yml
+++ b/models/staging/_sources.yml
@@ -8,12 +8,22 @@ sources:
     tables:
       - name: events
         description: "Raw events data containing event information and RSVPs"
+        loaded_at_field: "timestamp(cast(created / 1000 as bigint))" # SQL expression for conversion
+        freshness:
+          warn_after: {count: 7, period: day}
+          # error_after: {count: 14, period: day} # Optional: error if older than 14 days
         
       - name: groups
         description: "Raw groups data containing information about Meetup groups"
+        freshness:
+          warn_after: {count: 30, period: day} # Check if queryable
         
       - name: users
         description: "Raw users data containing user information and group memberships"
+        freshness:
+          warn_after: {count: 30, period: day} # Check if queryable
         
       - name: venues
         description: "Raw venues data containing location information for events"
+        freshness:
+          warn_after: {count: 30, period: day} # Check if queryable

--- a/models/staging/_staging.yml
+++ b/models/staging/_staging.yml
@@ -46,37 +46,48 @@ models:
           - not_null
           - unique
 
-  - name: stg_rsvps
+  - name: stg_event_rsvps
     description: >
-      Flattened RSVPs data extracted from the nested array in events.
-      Each row represents one user's RSVP to a specific event.
+      Flattened RSVP data extracted from the nested array in raw_events. 
+      Each row represents a single user's RSVP to a specific event, 
+      identified by user_event_key.
     columns:
-      - name: group_id
-        description: Unique identifier of the group that organized the event
+      - name: event_id
+        description: Unique identifier for the event this RSVP belongs to
         tests:
           - not_null
       
-      - name: event_name
-        description: Title of the event
+      - name: event_id_clean
+        description: Cleaned version of the event_id, used for partitioning
         tests:
           - not_null
-      
-      - name: event_status
-        description: Status of the event (past, upcoming)
       
       - name: user_id
         description: Unique identifier of the user that RSVPed for this event
         tests:
           - not_null
       
-      - name: rsvp_time
-        description: Timestamp of when the user gave their RSVP
+      - name: rsvp_response
+        description: Yes, No, or Waitlist, the indication of whether this user will attend the event
       
-      - name: response
-        description: Yes or No, the indication of whether this user will attend the event
-      
-      - name: guests
+      - name: rsvp_last_modified_at
+        description: Timestamp of when the user last modified their RSVP
+        tests:
+          - not_null
+
+      - name: rsvp_guests
         description: Number of guests that the user is planning to bring to the event
+        
+      - name: user_event_key
+        description: Surrogate key for the RSVP, generated from event_id and user_id
+        tests:
+          - not_null
+          - unique
+          
+      - name: event_created_at
+        description: Timestamp when the parent event was created
+        tests:
+          - not_null
 
   - name: stg_groups
     description: >
@@ -173,10 +184,11 @@ models:
       - name: topic
         description: The topic name or category that the group is associated with
         
-  - name: stg_user_memberships
+  - name: stg_memberships
     description: >
-      Flattened memberships data extracted from the nested array in users.
-      Each row represents one user's membership in a specific group.
+      Flattened membership data extracted from the nested array in raw_users.
+      Each row represents a user's membership in a specific group, 
+      identified by membership_key (user_id, group_id).
     columns:
       - name: user_id
         description: Unique identifier of the user
@@ -190,3 +202,11 @@ models:
       
       - name: joined_at
         description: Timestamp of when the user joined the group
+        tests:
+          - not_null # Assuming joined_at should always exist for a membership
+          
+      - name: membership_key
+        description: Surrogate key for the membership, generated from user_id and group_id
+        tests:
+          - not_null
+          - unique


### PR DESCRIPTION
- Add comprehensive YAML documentation and primary key tests (not_null, unique, relationships) for:
  - stg_event_rsvps (user_event_key)
  - stg_memberships (membership_key)
  - fact_venue_activity (venue_sk, activity_date)
  - fact_group_memberships (membership_sk)
  - fact_group_activity (group_sk, activity_date)
- Implement deduplication in stg_memberships to ensure primary key uniqueness.
- Fix bug in fact_venue_activity preventing null activity_date.
- Configure source freshness checks for all raw sources in _sources.yml:
  - events: Use loaded_at_field with SQL conversion for Unix timestamp, warn after 7 days.
  - groups, users, venues: Warn if not queryable after 30 days.
- Update README.md to reflect new test coverage, source freshness command, and features.