### PR TITLE
feat: clean event descriptions and update downstream models

### DIFF
--- a/macros/text_cleaning.sql
+++ b/macros/text_cleaning.sql
@@ -1,0 +1,35 @@
+{%- macro sp_remove_html(col) -%}
+    -- strip anything that looks like a tag
+    regexp_replace({{ col }}, '<[^>]+>', ' ')
+{%- endmacro %}
+
+{%- macro sp_html_decode(col) -%}
+    -- Spark doesn’t have a native “HTML unescape”, so replace the
+    -- handful that show up 99 % of the time.
+    regexp_replace(
+      regexp_replace(
+        regexp_replace(
+          regexp_replace(
+            regexp_replace({{ col }}, '&nbsp;', ' '),
+          '&amp;',  '&'),
+        '&lt;',   '<'),
+      '&gt;',   '>'),
+    '&quot;', '"')
+{%- endmacro %}
+
+{%- macro sp_collapse_ws(col) -%}
+    trim(regexp_replace({{ col }}, '\\s+', ' '))
+{%- endmacro %}
+
+{%- macro sp_dedupe_paragraphs(col) -%}
+    {%- set delim = '¶' -%}         -- rare UTF-8 char
+    array_join(
+        array_distinct(
+            filter(
+                transform(split({{ col }}, '\\n+'), x -> trim(x)),
+                x -> length(x) > 0
+            )
+        ),
+        '{{ delim }}'
+    )
+{%- endmacro %}

--- a/models/intermediate/int_events_with_venues.sql
+++ b/models/intermediate/int_events_with_venues.sql
@@ -50,7 +50,7 @@ event_with_keys as (
         -- Event information
         , events_latest.group_id
         , events_latest.event_name
-        , events_latest.event_description
+        , events_latest.event_description_clean as event_description
         , events_latest.event_created_at
         , events_latest.event_start_time
         , events_latest.event_duration_seconds


### PR DESCRIPTION
- Add Spark SQL macros for HTML stripping, entity decoding, whitespace collapsing, and paragraph deduplication.
- Update stg_events to use these macros, creating event_description_clean.
- Implement Delta Lake column mapping pre-hook in stg_events.
- Update int_events_with_venues to use event_description_clean.