### PR TITLE
feat: add primary key tests and docs for staging and PBI models

### DIFF
--- a/macros/text_utils.sql
+++ b/macros/text_utils.sql
@@ -1,0 +1,3 @@
+{% macro remove_html_tags(column_name) %}
+    regexp_replace({{ column_name }}, '<[^>]*>', '')
+{% endmacro %}

--- a/models/pbi/_pbi.yml
+++ b/models/pbi/_pbi.yml
@@ -6,6 +6,9 @@ models:
     columns:
       - name: date_day
         description: "The specific date."
+        tests:
+          - not_null
+          - unique
       - name: day_name
         description: "The full name of the day of the week (e.g., Monday)."
       # Add other relevant dim_date columns here with descriptions
@@ -47,6 +50,7 @@ models:
         description: "Surrogate key for the event, cast to string."
         tests:
           - not_null
+          - unique
       - name: venue_sk
         description: "Foreign key to dim_venues (venue_sk), cast to string."
       - name: group_sk
@@ -55,11 +59,20 @@ models:
 
   - name: pbi_fact_group_activity
     description: "Power BI specific version of fact_group_activity. Casts group_sk to string for PBI compatibility."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - group_sk
+            - activity_date
     columns:
       - name: group_sk
         description: "Foreign key to dim_groups (group_sk), cast to string."
+        tests:
+          - not_null
       - name: activity_date
         description: "Date of the group activity."
+        tests:
+          - not_null
       # Add other relevant fact_group_activity columns here with descriptions
 
   - name: pbi_fact_group_memberships
@@ -92,9 +105,18 @@ models:
 
   - name: pbi_fact_venue_activity
     description: "Power BI specific version of fact_venue_activity. Casts venue_sk to string for PBI compatibility."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - venue_sk
+            - activity_date
     columns:
       - name: venue_sk
         description: "Foreign key to dim_venues (venue_sk), cast to string."
+        tests:
+          - not_null
       - name: activity_date
         description: "Date of the venue activity."
+        tests:
+          - not_null
       # Add other relevant fact_venue_activity columns here with descriptions

--- a/models/staging/_staging.yml
+++ b/models/staging/_staging.yml
@@ -184,6 +184,12 @@ models:
       - name: topic
         description: The topic name or category that the group is associated with
         
+      - name: topic_key
+        description: Surrogate key for the group topic, generated from group_id and topic
+        tests:
+          - not_null
+          - unique
+
   - name: stg_memberships
     description: >
       Flattened membership data extracted from the nested array in raw_users.
@@ -199,14 +205,34 @@ models:
         description: Unique identifier of the group the user has joined
         tests:
           - not_null
-      
+
       - name: joined_at
-        description: Timestamp of when the user joined the group
+        description: Timestamp when the user joined the group
         tests:
-          - not_null # Assuming joined_at should always exist for a membership
-          
+          - not_null
+
       - name: membership_key
         description: Surrogate key for the membership, generated from user_id and group_id
         tests:
           - not_null
           - unique
+
+  - name: stg_users
+    description: >
+      Staged users data with standardized field names.
+      Contains user profile information.
+    columns:
+      - name: user_id
+        description: Unique identifier for the user (anonymized)
+        tests:
+          - not_null
+          - unique
+      
+      - name: city
+        description: City where the user resides
+      
+      - name: country
+        description: Country where the user resides
+      
+      - name: hometown
+        description: Town that the user specified as their home town

--- a/models/staging/stg_group_topics.sql
+++ b/models/staging/stg_group_topics.sql
@@ -1,3 +1,8 @@
+{{ config(
+    unique_key='topic_key',
+    on_schema_change='sync_all_columns'
+) }}
+
 with raw_data as (
     select * from {{ ref('raw_groups') }}
 ),
@@ -7,9 +12,14 @@ group_topics as (
     select
         group_id
         , exploded as topic
+        , {{ dbt_utils.generate_surrogate_key(['group_id', 'exploded']) }} as topic_key
     from 
         raw_data
         LATERAL VIEW EXPLODE(topics) exploded_table AS exploded
 )
 
-select * from group_topics
+select 
+    group_id,
+    topic,
+    topic_key
+from group_topics


### PR DESCRIPTION
- Added primary key tests (unique, not_null) and descriptions for:
  - stg_memberships (membership_key)
  - stg_group_topics (topic_key, also generated key in SQL)
- Added primary key tests for PBI models:
  - pbi_fact_venue_activity (venue_sk, activity_date)
  - pbi_fact_group_activity (group_sk, activity_date)
  - pbi_fact_events (event_sk)
  - pbi_dim_date (date_day)

Addresses issues related to missing primary key tests and ensures better data integrity and model documentation.